### PR TITLE
Deprecated APIs removed in 1.22 and 1.25 + release v1.4.0

### DIFF
--- a/chart/gvm/Chart.yaml
+++ b/chart/gvm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gvm
-version: 1.3.2
+version: 1.4.0
 appVersion: "21.04"
 description: The Greenbone Vulnerability Management Solution (previously known as Open Vulnerability Assessment System) i.e. a remote network security auditing tool
 keywords:

--- a/chart/gvm/templates/feeds-sync-cronjob.yaml
+++ b/chart/gvm/templates/feeds-sync-cronjob.yaml
@@ -1,5 +1,5 @@
 {{- if (or .Values.syncFeedsCronJob.enabled) }}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "gvm.fullname" . }}-feeds-sync

--- a/chart/gvm/templates/ingress.yaml
+++ b/chart/gvm/templates/ingress.yaml
@@ -1,10 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "gvm.fullname" . -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
Update chart to remove deprecated API :

- update Ingress `networking.k8s.io/v1beta1` to `networking.k8s.io/v1`
- update CronJob `batch/v1beta1` to `batch/v1`

Update version in Chart.yaml to v1.4.0